### PR TITLE
Removed System from SI in options.html

### DIFF
--- a/options.html
+++ b/options.html
@@ -112,7 +112,7 @@
 			<strong>1.234,56</strong> is not official SI style but it is widely used in Argentina, Austria, Belgium (Dutch), Bosnia and Herzegovina, Brazil, Chile, Colombia, Costa Rica, Croatia, Denmark, Germany, Greece, Indonesia, Italy, Netherlands, Romania, Serbia, Slovenia, Spain, Turkey, Vietnam. <br/>
 			<strong>1,234.56</strong> is not official SI style but it is widely used Canada (English-speaking; unofficial), China, Hong Kong, Ireland, Israel, Japan, Korea, Malaysia, México, New Zealand, Pakistan, Philippines, Singapore, Taiwan, Thailand, United Kingdom, United States. 
 		</p><br />
-        <p>As of 2019, the <strong>USA is the only country</strong> that has not officially adopted Metric / SI System, even though the <strong>Metric Conversion Act from 1975</strong> made the metric system "the preferred system of weights and measures for U.S. trade and commerce". Myanmar and Liberia officially adopted SI System recently. </p>
+        <p>As of 2019, the <strong>USA is the only country</strong> that has not officially adopted Metric / SI, even though the <strong>Metric Conversion Act from 1975</strong> made the metric system "the preferred system of weights and measures for U.S. trade and commerce". Myanmar and Liberia officially adopted SI recently. </p>
 		<button id="save" style="margin-top: 10px; margin-bottom: 10px; width: 100px; text-align: center;">Save Settings</button>
         <div id="status" style="color:seagreen; font-weight: bold;"></div>
 		<br />
@@ -124,7 +124,7 @@
 		<p>If this add-on doesn't work correctly on a certain page, <br />please send me an <strong>email</strong> with the problematic page link <a href="mailto:metric@milosparipovic.com">metric@milosparipovic.com</a> </p>
 		<p>This extension is now <strong>Open Source</strong> (<a href="https://github.com/m1l/Everything-Metric">https://github.com/m1l/Everything-Metric</a>)</p>
         <p>
-        SI System is a communication tool. Leave comments on your favorite blogs and other sites that still use USCS/Imperial system asking them to use international units, and let's make this extension unnecessary.</p>
+        SI is a communication tool. Leave comments on your favorite blogs and other sites that still use USCS/Imperial system asking them to use international units, and let's make this extension unnecessary.</p>
         <p>You may find my other free projects useful: <a href="http://uxd2.com/software.html">http://uxd2.com/software.html</a></p>
 		<script src="options.js"></script>
 	</body>


### PR DESCRIPTION
SI stands for Système international, SI System thus is redundant. Style choice tho, I understand if this is not merged

See [Wikipedia](https://en.wikipedia.org/wiki/International_System_of_Units#cite_note-2)