### PR TITLE
update to manifest v3

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,6 +6,9 @@ var useMO;
 var useGiga;
 var useSpaces;
 var useKelvin;
+var useBold;
+var useBrackets;
+var useMetricOnly;
 var convertBracketed;
 var enableOnStart;
 var matchIn;
@@ -15,7 +18,7 @@ var includeImproperSymbols;
 function updateIcon() {
     if (metricIsEnabled===true)
 	{
-		chrome.browserAction.setIcon({
+		chrome.action.setIcon({
 			path: {
                 "16": "icons/everything-metric-16.png",
                 "19": "icons/everything-metric-19.png",
@@ -25,12 +28,12 @@ function updateIcon() {
                 "96": "icons/everything-metric-96.png",
                 "128": "icons/everything-metric-128.png"
 			}
-		});        
-		chrome.browserAction.setTitle({title: "Automatic 𝗠𝗲𝘁𝗿𝗶𝗰/SI conversion is 𝗢𝗡.\nYou can customize it in 𝗘𝘅𝘁𝗲𝗻𝘀𝗶𝗼𝗻 𝗢𝗽𝘁𝗶𝗼𝗻𝘀"});  //𝗔𝗱𝗱-𝗼𝗻 for FF
+		});
+		chrome.action.setTitle({title: "Automatic 𝗠𝗲𝘁𝗿𝗶𝗰/SI conversion is 𝗢𝗡.\nYou can customize it in 𝗘𝘅𝘁𝗲𝗻𝘀𝗶𝗼𝗻 𝗢𝗽𝘁𝗶𝗼𝗻𝘀"});  //𝗔𝗱𝗱-𝗼𝗻 for FF
 	}
     else
 	{
-		chrome.browserAction.setIcon({
+		chrome.action.setIcon({
 			path: {
                 "16": "icons/everything-metric-16-off.png",
                 "19": "icons/everything-metric-19-off.png",
@@ -40,7 +43,7 @@ function updateIcon() {
                 "96": "icons/everything-metric-96-off.png"
 			}
 		});
-		chrome.browserAction.setTitle({title: "Automatic 𝗠𝗲𝘁𝗿𝗶𝗰/SI conversion is 𝗢𝗙𝗙.\nPress 𝗔𝗟𝗧+𝗠 to convert page without turning it ON"});            
+		chrome.action.setTitle({title: "Automatic 𝗠𝗲𝘁𝗿𝗶𝗰/SI conversion is 𝗢𝗙𝗙.\nPress 𝗔𝗟𝗧+𝗠 to convert page without turning it ON"});            
 	}
 }  
 
@@ -155,7 +158,7 @@ function restore_options() {
 }
 restore_options();
 
-chrome.browserAction.onClicked.addListener(function(tab){
+chrome.action.onClicked.addListener(function(tab){
     toggleMetric();
     chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
         chrome.tabs.reload(tabs[0].id);

--- a/contentscript.js
+++ b/contentscript.js
@@ -1231,7 +1231,7 @@ function InitRegex(){
 }        
 
 
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', async function() {
 
 	if (/docs\.google\./.test(window.location.toString()) ||
 		/drive\.google\./.test(window.location.toString()) ||
@@ -1245,32 +1245,30 @@ document.addEventListener('DOMContentLoaded', function() {
 		return;
 	}
 
-	chrome.runtime.sendMessage({
+	let response = await chrome.runtime.sendMessage({
 			message: "Is metric enabled"
-		},
-		function(response) {
-            metricIsEnabled = response.metricIsEnabled;
-			useComma = response.useComma;
-			useMM = response.useMM;
-			useRounding = response.useRounding;
-			useMO = response.useMO;
-			useGiga = response.useGiga;
-			useSpaces = response.useSpaces;
-			useKelvin = response.useKelvin;
-			useBold = response.useBold;
-			useBrackets = response.useBrackets;
-			useMetricOnly = response.useMetricOnly;
-            convertBracketed = response.convertBracketed;
-            matchIn = response.matchIn;
-            includeQuotes = response.includeQuotes;
-            includeImproperSymbols = response.includeImproperSymbols;
-			InitRegex();
-			if (response.metricIsEnabled === true) {
-                
-				let isamazon = false;
-				if (/\.amazon\./.test(window.location.toString())) isamazon = true;
-				if (/\.uk\//.test(window.location.toString())) isUK = true;
-                if (isamazon) {
+		});
+	metricIsEnabled = response.metricIsEnabled;
+	useComma = response.useComma;
+	useMM = response.useMM;
+	useRounding = response.useRounding;
+	useMO = response.useMO;
+	useGiga = response.useGiga;
+	useSpaces = response.useSpaces;
+	useKelvin = response.useKelvin;
+	useBold = response.useBold;
+	useBrackets = response.useBrackets;
+	useMetricOnly = response.useMetricOnly;
+	convertBracketed = response.convertBracketed;
+	matchIn = response.matchIn;
+	includeQuotes = response.includeQuotes;
+	includeImproperSymbols = response.includeImproperSymbols;
+	InitRegex();
+	if (response.metricIsEnabled === true) {
+		let isamazon = false;
+		if (/\.amazon\./.test(window.location.toString())) isamazon = true;
+		if (/\.uk\//.test(window.location.toString())) isUK = true;
+		if (isamazon) {
                     var div = document.getElementById("AmazonMetricHelper"); 
                     if (div===null)
                         div = document.createElement('div');
@@ -1280,14 +1278,12 @@ document.addEventListener('DOMContentLoaded', function() {
                     div.textContent = 'Converted to Metric!';    
                     document.body.appendChild(div);
                 }
-                isparsing=true;
-				walk(document.body);
-                isparsing=false;
-				if (useMO === true || isamazon === true)
-					initMO(document.body);
-			}
-		}
-	); 
+		isparsing=true;
+		walk(document.body);
+		isparsing=false;
+		if (useMO === true || isamazon === true)
+			initMO(document.body);
+	}
 }, false);
 /*
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "description": "Automatic page translation from American to International System of units",
   "author": "Milos Paripovic",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Everything Metric - Auto Unit Converter",
   "short_name": "Everything Metric",
   "version": "3.4",
@@ -18,7 +18,7 @@
     "tabs",
     "storage"
   ],
-  "browser_action": {
+  "action": {
     "default_icon": {
       "16": "icons/everything-metric-16.png",
       "19": "icons/everything-metric-19.png",
@@ -31,9 +31,8 @@
     "default_title": "Automatic Metric/SI conversion"
   },
   "background": {
-    "scripts": [
-      "background.js"
-    ]
+    "service_worker": "background.js",
+    "type": "module"
   },
   "content_scripts": [
     {
@@ -50,10 +49,7 @@
       ]
     }
   ],
-  "options_ui": {
-    "page": "options.html",
-    "chrome_style": true
-  },
+  "options_page": "options.html",
   "commands": {
     "parse_page_now": {
       "suggested_key": {


### PR DESCRIPTION
Chrome Web Store has a warning banner: `This extension may soon no longer be supported` which is probably due to using manifest v2.

Migration details: https://developer.chrome.com/docs/extensions/develop/migrate

* background -> service worker
* async sendMessage
* renamed some chrome APIs

It works on a recipe site and Amazon.com. Options page displays. Alt-M works.

Browser version: Chromium Version 133 on Debian GNU/Linux